### PR TITLE
[jsc] Feat/bn in

### DIFF
--- a/examples/jet_substructure/README.md
+++ b/examples/jet_substructure/README.md
@@ -48,9 +48,9 @@ The following results are attained when training on a CPU and synthesising with 
 
 | Network Architecture  | Test Accuracy (%) | LUTs  | Flip Flops    | Fmax (Mhz)    | Latency (Cycles)  |
 | --------------------- | ----------------- | ----- | ------------- | ------------- | ----------------- |
-| JSC-S                 |              68.8 |   232 |           268 |       1394.70 |                 5 |
-| JSC-M                 |              71.5 | 14576 |           803 |        596.66 |                 5 |
-| JSC-L                 |              72.6 | 38925 |          2418 |        485.44 |                 6 |
+| JSC-S                 |              69.4 |   241 |           269 |       1400.56 |                 5 |
+| JSC-M                 |              71.9 | 15009 |           848 |        583.77 |                 5 |
+| JSC-L                 |              73.0 | 36336 |          2771 |        395.88 |                 6 |
 
 Note, the model architectures reflect the architectures described in our [FPL'20 paper](https://arxiv.org/abs/2004.03021).
 

--- a/examples/jet_substructure/models.py
+++ b/examples/jet_substructure/models.py
@@ -41,8 +41,9 @@ class JetSubstructureNeqModel(nn.Module):
             out_features = self.num_neurons[i]
             bn = nn.BatchNorm1d(out_features)
             if i == 1:
+                bn_in = nn.BatchNorm1d(in_features)
                 input_bias = ScalarBiasScale(scale=False, bias_init=-0.25)
-                input_quant = QuantBrevitasActivation(QuantHardTanh(model_config["input_bitwidth"], max_val=1., narrow_range=False, quant_type=QuantType.INT, scaling_impl_type=ScalingImplType.PARAMETER), pre_transforms=[input_bias])
+                input_quant = QuantBrevitasActivation(QuantHardTanh(model_config["input_bitwidth"], max_val=1., narrow_range=False, quant_type=QuantType.INT, scaling_impl_type=ScalingImplType.PARAMETER), pre_transforms=[bn_in, input_bias])
                 output_quant = QuantBrevitasActivation(QuantReLU(bit_width=model_config["hidden_bitwidth"], max_val=1.61, quant_type=QuantType.INT, scaling_impl_type=ScalingImplType.PARAMETER), pre_transforms=[bn])
                 mask = RandomFixedSparsityMask2D(in_features, out_features, fan_in=model_config["input_fanin"])
                 layer = SparseLinearNeq(in_features, out_features, input_quant=input_quant, output_quant=output_quant, sparse_linear_kws={'mask': mask})


### PR DESCRIPTION
Added batch norm before the first input quantization for the jet substructure examples, increasing accuracy by ~0.5% for all topologies.